### PR TITLE
Fix rvb-test-model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,28 @@ Installation
 
 We test using Python 2.7, 3.5 and 3.6. Other Python versions might work as well, but we recommend using Python 3.5 or newer.
 
+Using pip
+^^^^^^^^^
+
 .. code-block:: bash
 
    pip install robust-vision-benchmark
+
+
+Latest version
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   git clone https://github.com/bethgelab/robust-vision-benchmark.git
+   cd robust-vision-benchmark && python setup.py install && cd ..
+
+Now, you need to copy data directory to the installation directory.
+
+.. code-block:: bash
+
+   d=$(python -c "import os, robust_vision_benchmark as rvb; print(os.path.dirname(rvb.__file__))")
+   cp -r robust-vision-benchmark/data $d
 
 Submitting a model
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ Put the Dockerfile, script, data and other required files into a folder, e.g. *m
 
    rvb-test-model model/
 
+Note that you need to have nvidia-docker installed and in the path for this to run.
 You can find an example in *examples/model/*.
 
 Upload the submission

--- a/bin/rvb-test-model
+++ b/bin/rvb-test-model
@@ -133,6 +133,9 @@ def test_model(directory, no_cache):
         if model.channel_axis() == 1:
             image = np.transpose(image, [2, 0, 1])
 
+        # put image in bounds
+        image = image * ((max_ - min_) / 255) + min_
+
         label = int(os.path.basename(filename).split('.')[0].split('_')[1])
 
         pred_label = model.batch_predictions(image[None])

--- a/bin/rvb-test-model
+++ b/bin/rvb-test-model
@@ -13,7 +13,7 @@ import glob
 
 
 def test_model(directory, no_cache):
-    print('##### INITIALIZING DOCKER IMAGE ######')
+    print('##### BUILDING DOCKER IMAGE ######')
     print('Analyzing model in folder "{}", uses GPU=0.'.format(directory))
     gpu = 0
 
@@ -40,22 +40,45 @@ def test_model(directory, no_cache):
     cmd += "-e GPU={gpu} -e PORT={port} --name={cn} rvb-test-model"
     cmd = cmd.format(port=port, gpu=gpu, cn=container_name)
     subprocess.Popen(cmd, shell=True).wait()
-    # TODO: attach to container to print output before "  * Running on http://"
+
+    # attach to container to print output in case of failures
+    cmd = "docker attach {}".format(container_name)
+    dump = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE)
 
     # get IP
-    print('##### CONNECTING TO THE RUNNING SERVER ######')
     form = '{{ .NetworkSettings.IPAddress }}'
     cmd = "docker inspect --format='{}' {}".format(form, container_name)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    p.wait()
     ip = p.stdout.read()[:-1].decode('UTF-8')
     print('Received IP of server: ', ip)
 
     # wait until start of server
     print('Waiting for server to start.')
-    cmd = 'wget -qO - --tries 30 --retry-connrefused http://{}:{}'
-    subprocess.Popen(cmd.format(ip, port), shell=True).wait()
+    for i in range(30):
+        # check if the server is up
+        cmd = 'wget -qO - --tries 2 --retry-connrefused http://{}:{}'
+        if subprocess.Popen(cmd.format(ip, port), shell=True).wait() == 0:
+            break
+
+        # check if the container is running
+        form = "{{ .State.Running }}"
+        cmd = "docker inspect --format='{}' {}".format(form, container_name)
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        p.wait()
+        running = p.stdout.read().decode('UTF-8').strip() == 'true'
+        if not running:
+            # print any errors in the code and exit
+            print(dump.stderr.read().decode('UTF-8'))
+            form = "{{ .State.ExitCode }}"
+            cmd = "docker inspect --format='{}' {}".format(
+                form, container_name)
+            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+            p.wait()
+            return exit(int(p.stdout.read().decode('UTF-8').strip()))
 
     # start client model
+    print('##### CONNECTING TO THE RUNNING SERVER ######')
     model = robust_vision_benchmark.BSONModel('http://{}:{}'.format(ip, port))
 
     print('Server version', model.server_version())

--- a/bin/rvb-test-model
+++ b/bin/rvb-test-model
@@ -106,7 +106,7 @@ def test_model(directory, no_cache):
     data_path = os.path.dirname(
         os.path.abspath(robust_vision_benchmark.__file__))
     data_path = os.path.join(
-        data_path, '..', 'data', model.dataset().lower(), '*.png')
+        data_path, 'data', model.dataset().lower(), '*.png')
 
     print(data_path)
     filenames = glob.glob(data_path)

--- a/bin/rvb-test-model
+++ b/bin/rvb-test-model
@@ -13,37 +13,37 @@ import glob
 
 
 def test_model(directory, no_cache):
-    print('##### START CHECK ######')
+    print('##### INITIALIZING DOCKER IMAGE ######')
     print('Analyzing model in folder "{}", uses GPU=0.'.format(directory))
     gpu = 0
 
     container_name = 'rvb-test-model-container'
 
     # remove old container if exists
-    subprocess.Popen("docker rm -f {}".format(container_name),
-                     shell=True).wait()
+    cmd = 'docker rm -f {}'.format(container_name)
+    subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).wait()
 
     # build model container
     if no_cache:
         print('Not using cache for docker build')
-        subprocess.Popen(
-            "docker build --no-cache -t rvb-test-model {}".format(
-                directory), shell=True).wait()
+        cmd = "docker build --no-cache -t rvb-test-model {}".format(directory)
+        subprocess.Popen(cmd, shell=True).wait()
     else:
         print('Using cache for docker build (if exists)')
-        subprocess.Popen(
-            "docker build -t rvb-test-model {}".format(directory),
-            shell=True).wait()
+        cmd = "docker build -t rvb-test-model {}".format(directory)
+        subprocess.Popen(cmd, shell=True).wait()
 
     # start model container
+    print('##### RUNNING DOCKER CONTAINER ######')
     port = 61220
-    subprocess.Popen(
-        "NV_GPU={gpu} nvidia-docker run --expose={port} -d -p {port}:{port} "
-        "-e GPU={gpu} -e PORT={port} --name={cn} "
-        "rvb-test-model".format(
-            port=port, gpu=gpu, cn=container_name), shell=True).wait()
+    cmd = "NV_GPU={gpu} nvidia-docker run --expose={port} -d -p {port}:{port} "
+    cmd += "-e GPU={gpu} -e PORT={port} --name={cn} rvb-test-model"
+    cmd = cmd.format(port=port, gpu=gpu, cn=container_name)
+    subprocess.Popen(cmd, shell=True).wait()
+    # TODO: attach to container to print output before "  * Running on http://"
 
     # get IP
+    print('##### CONNECTING TO THE RUNNING SERVER ######')
     form = '{{ .NetworkSettings.IPAddress }}'
     cmd = "docker inspect --format='{}' {}".format(form, container_name)
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
@@ -52,9 +52,8 @@ def test_model(directory, no_cache):
 
     # wait until start of server
     print('Waiting for server to start.')
-    cmd = 'wget -qO - --tries 30 --retry-connrefused http://{}:{}'.format(
-        ip, port)
-    subprocess.Popen(cmd, shell=True).wait()
+    cmd = 'wget -qO - --tries 30 --retry-connrefused http://{}:{}'
+    subprocess.Popen(cmd.format(ip, port), shell=True).wait()
 
     # start client model
     model = robust_vision_benchmark.BSONModel('http://{}:{}'.format(ip, port))
@@ -62,6 +61,7 @@ def test_model(directory, no_cache):
     print('Server version', model.server_version())
 
     # get predictions and/or gradient for model
+    print('Performing basic checks for the code.')
     image_size = model.image_size()
     channel_axis = model.channel_axis()
 

--- a/bin/rvb-upload
+++ b/bin/rvb-upload
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import os
 import argparse
 import subprocess
 
@@ -12,15 +13,20 @@ def upload(directory):
         'before submitting your model or attack. '
         'Press [Enter] to continue ...')
 
-    print('Creating archive for submission in folder "{}"'.format(directory))
+    abspath = os.path.abspath(directory)
+    directory, folder = os.path.split(abspath)
+
+    os.chdir(directory)
+    print('Creating archive for submission in folder "{}"'.format(folder))
     subprocess.Popen(
-        "tar czf submission.tar.gz {}".format(directory), shell=True).wait()
+        "tar czf submission.tar.gz {}".format(folder), shell=True).wait()
 
     print('Uploading submission')
     p = subprocess.Popen(
         "curl --upload-file ./submission.tar.gz "
         "https://transfer.sh/submission.tar.gz",
         shell=True, stdout=subprocess.PIPE)
+    p.wait()
     url = p.stdout.read().decode('UTF-8')
 
     print("Your submission has been uploaded to {}".format(url))

--- a/robust_vision_benchmark/server.py
+++ b/robust_vision_benchmark/server.py
@@ -100,7 +100,7 @@ def _model_server(
     assert dataset in ['MNIST', 'CIFAR', 'IMAGENET']
 
     if port is None:
-        port = os.environ.get('PORT')
+        port = int(os.environ.get('PORT'))
     if port is None:
         port = 62222
 
@@ -194,7 +194,7 @@ def attack_server(attack, port=None):
     assert attack is not None
 
     if port is None:
-        port = os.environ.get('PORT')
+        port = int(os.environ.get('PORT'))
     if port is None:
         port = 52222
 


### PR DESCRIPTION
Using pip is not sufficient for rvb-test-model to run successfully. 
Here are some minor changes that make it run:
  - convert port number to int if given as env variable
  - put the test images in the bounds range
  - copy the test images to an appropriate folder
  - describe the correct installation process in README

If for some reason the main.py had errors, the output is not very informative.
Now, if there is a runtime error or exception the code exits and prints the error.